### PR TITLE
Document the rules extraction and refactor

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,11 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PlutoStaticHTML = "359b1769-a58e-495b-9770-312e911026ad"
 SIRUS = "cdeec39e-fb35-4959-aadb-a1dd5dede958"
 
 [compat]
 Documenter = "0.27"
+LiveServer = "1"
 PlutoStaticHTML = "6"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -6,6 +7,7 @@ PlutoStaticHTML = "359b1769-a58e-495b-9770-312e911026ad"
 SIRUS = "cdeec39e-fb35-4959-aadb-a1dd5dede958"
 
 [compat]
+CairoMakie = "0.10"
 Documenter = "0.27"
 LiveServer = "1"
 PlutoStaticHTML = "6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,5 @@
 is_ci = haskey(ENV, "CI")
 
-if !is_ci
-    using Pkg
-    Pkg.activate(@__DIR__)
-    Pkg.develop(; path=dirname(@__DIR__))
-    Pkg.instantiate()
-end
-
 using Documenter:
     DocMeta,
     HTML,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,12 @@
+is_ci = haskey(ENV, "CI")
+
+if !is_ci
+    using Pkg
+    Pkg.activate(@__DIR__)
+    Pkg.develop(; path=dirname(@__DIR__))
+    Pkg.instantiate()
+end
+
 using Documenter:
     DocMeta,
     HTML,
@@ -30,12 +39,12 @@ function build()
 end
 
 pages = [
-    "Implementation Details" => "implementation-details.md",
+    "Implementation Overview" => "implementation-overview.md",
     "API" => "api.md"
 ]
 
-# Whether to build the notebooks; defaults to "true".
-do_build_notebooks = get(ENV, "BUILD_DOCS_NOTEBOOKS", "true") == "true"
+# Whether to build the notebooks; defaults to "false".
+do_build_notebooks = is_ci
 
 if do_build_notebooks
     build()
@@ -45,7 +54,7 @@ if do_build_notebooks
     pushfirst!(pages, "SIRUS" => "index.md")
 end
 
-prettyurls = get(ENV, "CI", nothing) == "true"
+prettyurls = is_ci
 format = HTML(; mathengine=MathJax3(), prettyurls)
 modules = [SIRUS]
 strict = do_build_notebooks

--- a/docs/serve.jl
+++ b/docs/serve.jl
@@ -1,0 +1,11 @@
+# Serve docs with
+# ```
+# $ julia -i docs/serve.jl
+# ```
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.develop(; path=dirname(@__DIR__))
+using LiveServer
+using SIRUS
+
+LiveServer.servedocs()

--- a/docs/src/implementation-overview.md
+++ b/docs/src/implementation-overview.md
@@ -1,6 +1,6 @@
-# Implementation details
+# Implementation Overview
 
-This page describes an high-level overview of the implementation.
+This page provides a high-level overview of the implementation.
 In essence, this overview is a combination of three things:
 
 1. Section 8.1.1 Regression Trees and 8.1.2 Classification trees (James et al., [2021](https://doi.org/10.1007/978-1-0716-1418-1)).

--- a/docs/src/implementation-overview.md
+++ b/docs/src/implementation-overview.md
@@ -183,9 +183,12 @@ The SIRUS algorithm solves that by simplifying the model itself instead of only 
 ## Rule Selection and Post-Treatment
 
 The aim of rule selection is to remove as many rules as possible without affecting the predictive performance too much.
-This is similar to pruning in artificial neural networks, where the least important neurons are removed.
-This is done via two ways.
+This is similar to the _Tree Pruning_ that happens in Random Forests (James et al., [2021](https://doi.org/10.1007/978-1-0716-1418-1); Section 8.1).
+This is also similar to pruning in artificial neural networks, where the least important neurons are removed.
+In the SIRUS algorithm, this pruning is done via two ways.
 Firstly, by pruning the many identical rules in the different forests, which are identical thanks to tree stabilization done when building the trees.
+The tree stabilization makes the rules identical because the splitpoints are identical in the different trees.
+For example, the stabilization could result in the rules ``\text{if } x_1 < 3 \text{ then, } ... \text{ else } ...`` and ``\text{if } x_1 < 3 \text{ then, } ... \text{ else } ...`` both existing in different trees.
 Secondly, by pruning rules which are a linear combination of other rules.
 
 The first step requires setting a hyperparameter ``p_0`` in the original algorithm.

--- a/docs/src/implementation-overview.md
+++ b/docs/src/implementation-overview.md
@@ -5,9 +5,9 @@ In essence, this overview is a combination of three things:
 
 1. Section 8.1.1 Regression Trees and 8.1.2 Classification trees (James et al., [2021](https://doi.org/10.1007/978-1-0716-1418-1)).
 2. The SIRUS algorithm description (Bénard et al., [2021](http://proceedings.mlr.press/v130/benard21a.html)).
-3. Some implementation details, as obtained by trial and error and the help of Clement Bénard, which were missing from aforementioned sources.
+3. Some implementation details, as obtained by trial and error and by correspondence with Clement Bénard, which were missing from aforementioned sources.
 
-## Fit stabilized trees
+## Fit Stabilized Trees
 
 The tree fitting procedure is very similar to the algorithm explanation in James et al. ([2021](https://doi.org/10.1007/978-1-0716-1418-1)).
 In summary:
@@ -61,12 +61,12 @@ where ``p_\text{classes}`` denotes the fraction (proportion) of items from the c
 Note that this equation is optimized for computational efficiency.
 For the full derivation from the original equation, see _Gini impurity_ at [Wikipedia](https://en.wikipedia.org/wiki/Decision_tree_learning#Gini_impurity).
 
-## Convert the trees to rules
+## Rule Generation
 
 After creating many trees, the SIRUS algorithm converts these trees to rules.
 One of the first of such rule-based models was the RuleFit algorithm (Friedman & Popescu, [2008](http://www.jstor.org/stable/30245114)).
 The idea behind these models is that any tree can be expressed as a set of rules.
-For example, take the following tree with nodes ``n_1, n_2, ..., n_5``.
+For example, say we have the following tree with nodes ``n_1, n_2, ..., n_5``.
 
 ```@setup tree
 using CairoMakie
@@ -147,7 +147,7 @@ end
 plot_tree() # hide
 ```
 
-and let's say that this tree was generated from a tree fitting procedure as described above.
+and say that this tree was generated from a tree fitting procedure as described above.
 From this representation, we can see that node ``n_1`` splits the feature ``x_1`` on 3.
 If ``x_1 < 3``, then the prediction will go to ``n_2`` and if ``x \geq 3``, then the prediction will take the content of ``n_3``.
 In ``n_2``, the prediction will be made based on ``n_4`` or ``n_5`` depending on whether feature ``x_2`` is smaller than or greater or equal to 5.
@@ -159,4 +159,55 @@ For example, the path to ``n_3`` can be converted to
 \text{if } x_1 \geq 3, \text{ then } A \text{ else } B,
 ```
 
-where ``A`` considers all points that satisfy ``n_3`` and ``B`` considers all points that do not satisfy the rule constraints.
+where ``A`` considers all points that satisfy the rule constraints represented by the path to ``n_3`` (``x_1 \geq 3``) and ``B`` considers all points that do not satisfy the rule constraints (``x_1 < 3``).
+Similarly, the path to ``n_4`` can be converted to
+
+```math
+\text{if } x_1 < 3 \: \& \: x_2 < 5, \text{ then } C \text{ else } D,
+```
+
+where ``C`` considers all the points that satisfy the rule constraints and ``D`` considers all the points that do not satisfy the rule constraints.
+
+Unlike regular decision trees, rule-based models are typically restricted to a depth of 2 for reasons that will be explained later.
+For now, say we have a large number of trees, typically around 1500, with a depth of at most 2, then we can estimate that the number of generated rules will be at most 6 * 1500 = 9000.
+I'm taking 6 here since a tree of depth 2 can have at most 7 nodes, of which all but the root are converted to a separate rule.
+In other words, "both internal and external nodes are extracted from the trees of the random forest to generate a large collection of rules, typically ``10^4``" (Bénard et al., [2021](http://proceedings.mlr.press/v130/benard21a.html), Section _Rule generation_).
+
+Obviously, thousands of rules are not interpretable.
+Just like random forests, each prediction can be traced back to exactly how it was made.
+However, thousands of additions and multiplications are hard to interpret and explain.
+That's why visualizations based on SHAP are often used (e.g., Molnar, [2023](https://christophm.github.io/interpretable-ml-book/)).
+Still, these visualizations simplify the model such that feature importances becomes explainable, but they do not fully explain how predictions are made.
+The SIRUS algorithm solves that by simplifying the model itself instead of only simplifying the model explanation.
+
+## Rule Selection and Post-Treatment
+
+The aim of rule selection is to remove as many rules as possible without affecting the predictive performance too much.
+This is similar to pruning in artificial neural networks, where the least important neurons are removed.
+This is done via two ways.
+Firstly, by pruning the many identical rules in the different forests, which are identical thanks to tree stabilization done when building the trees.
+Secondly, by pruning rules which are a linear combination of other rules.
+
+The first step requires setting a hyperparameter ``p_0`` in the original algorithm.
+This hyperparameter specifies a threshold which is then used to remove rules with a occurence frequency below ``p_0``.
+The implementation in this Julia package ignores this step because it is superseeded by the second step and because it is quite difficult to pick the right ``p_0``.
+In other words, this step is ignored because it seems like a premature optimization (but I'm happy to be proven wrong of course).
+
+The second step is more important and more involved.
+As said before, the second step is to remove the least important linear combinations of other rules.
+An example of this is shown in the original paper (Bénard et al., [2021](http://proceedings.mlr.press/v130/benard21a.html), Table 3 (the second) in Section 4 _Post-treatment Illustration_ of the Supplementary PDF).
+
+The implementation for this can be done by converting the training data to a feature space in which each rule becomes a binary feature indicating whether the data point satisfies the constraint or not.
+This is quite computationally intensive since there is a lot of duplication in the data and it doesn't guarantee that all cases of duplication will be found since some may not be in the training set.
+Luckily, D.W. on StackExchange (https://cs.stackexchange.com/questions/152803) has provided a solution, which I will repeat here.
+The idea is to remove each rule ``r`` when it is linearly dependent on the preceding rules.
+
+To do this, observe that a rule of the form ``A \: \& \: B`` can only depend on rules that use some combination of ``A``, ``!A``, ``B``, and/or ``!B``.
+This works by iteratively calculating the rank and seeing whether the rank increases.
+
+We can assume that we are limited to a set of rules where either `A & B`, `A & !B`, `!A & B`, `!A & !B`, `A`, `!A`, `B`, `!B` or `True`.
+This last case is not a valid rule in this algorithm, so that will not happen.
+Now, given `A` and `B`, we can create a binary matrix with a row for `A & B`, `A & !B`, `!A & B`, `!A & !B`.
+Next, generate one column containing `true`s and one column for each rule in `rules`.
+In each column, answer whether the rule holds for some point that satisifies the conditional.
+Next, calculate the rank and see whether the rank increases when adding additional rules.

--- a/docs/src/implementation-overview.md
+++ b/docs/src/implementation-overview.md
@@ -211,3 +211,4 @@ Now, given `A` and `B`, we can create a binary matrix with a row for `A & B`, `A
 Next, generate one column containing `true`s and one column for each rule in `rules`.
 In each column, answer whether the rule holds for some point that satisifies the conditional.
 Next, calculate the rank and see whether the rank increases when adding additional rules.
+If the rank increases, then the added rule was not linearly dependent and if the rank does not increase, then the added rule is linearly dependent with earlier added rules.

--- a/docs/src/sirus.jl
+++ b/docs/src/sirus.jl
@@ -534,8 +534,8 @@ function _odds_plot(e::PerformanceEvaluation)
 		t_std = round(std(thresholds); digits=1)
 		
 		for (rule, weight) in rw
-			left = last(rule.then_probs)::Float64
-			right = last(rule.else_probs)::Float64
+			left = last(rule.then)::Float64
+			right = last(rule.otherwise)::Float64
 			t::Float64 = _threshold(rule)
 			ratio = log((right) / (left))
 			# area = πr²

--- a/docs/src/sirus.jl
+++ b/docs/src/sirus.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.15
+# v0.19.26
 
 using Markdown
 using InteractiveUtils
@@ -337,6 +337,23 @@ md"""
 ## Appendix
 """
 
+# ╔═╡ ede038b3-d92e-4208-b8ab-984f3ca1810e
+function _plot_cutpoints(data::AbstractVector)
+	fig = Figure(; resolution=(800, 100))
+	ax = Axis(fig[1, 1])
+	cps = Float64.(unique(cutpoints(data, 10)))
+	scatter!(ax, data, fill(1, length(data)))
+	vlines!(ax, cps; color=:black, linestyle=:dash)
+	textlocs = [(c, 1.1) for c in cps]
+	for cutpoint in cps
+		annotation = string(round(cutpoint; digits=2))::String
+		text!(ax, cutpoint + 0.2, 1.08; text=annotation, textsize=13)
+	end
+	ylims!(ax, 0.9, 1.2)
+	hideydecorations!(ax)
+	return fig
+end;
+
 # ╔═╡ 93a7dd3b-7810-4021-bf6e-ae9c04acea46
 _rng(seed::Int=1) = StableRNG(seed);
 
@@ -358,23 +375,6 @@ end;
 # ╔═╡ 0ca8bb9a-aac1-41a7-b43d-314a4029c205
 # hideall
 S = SIRUS;
-
-# ╔═╡ ede038b3-d92e-4208-b8ab-984f3ca1810e
-function _plot_cutpoints(data::AbstractVector)
-	fig = Figure(; resolution=(800, 100))
-	ax = Axis(fig[1, 1])
-	cps = Float64.(unique(cutpoints(data, 10)))
-	scatter!(ax, data, fill(1, length(data)))
-	vlines!(ax, cps; color=:black, linestyle=:dash)
-	textlocs = [(c, 1.1) for c in cps]
-	for cutpoint in cps
-		annotation = string(round(cutpoint; digits=2))::String
-		text!(ax, cutpoint + 0.2, 1.08; text=annotation, textsize=13)
-	end
-	ylims!(ax, 0.9, 1.2)
-	hideydecorations!(ax)
-	return fig
-end;
 
 # ╔═╡ 9db18ac7-4508-4861-8854-3e19d5218309
 function register_haberman()

--- a/src/SIRUS.jl
+++ b/src/SIRUS.jl
@@ -27,6 +27,7 @@ include("forest.jl")
 include("classification.jl")
 include("regression.jl")
 include("rules.jl")
+include("ruleshow.jl")
 include("weights.jl")
 export TreePath
 include("dependent.jl")

--- a/src/dependent.jl
+++ b/src/dependent.jl
@@ -158,7 +158,6 @@ end
 """
 Return the subset of `rules` which are not linearly dependent.
 This is based on a complex heuristic involving calculating the rank of the matrix, see above StackExchange link for more information.
-Note that calculating the rank is expensive, so make sure to pre-filter before calling this function.
 Also note that this method assumes that the rules are assumed to be in ordered by frequency of occurence in the trees.
 This assumption is used to filter less common rules when finding linearly dependent rules.
 """

--- a/src/dependent.jl
+++ b/src/dependent.jl
@@ -29,16 +29,6 @@ function _satisfies(unique_features::Vector{Int}, point::Vector, rule::Rule)
 end
 
 """
-Return whether each rule in `rules` is linearly dependent on a combination of rules before it.
-This works by iteratively calculating the rank and seeing whether the rank increases.
-
-To generate points for the rank calculation, assume that we are limited to a set of rules where either `A & B`, `A & !B`, `!A & B`, `!A & !B`, `A`, `!A`, `B`, `!B` or `True`.
-This last case is not a valid rule in this algorithm, so that will not happen.
-Now, given `A` and `B`, we can create a binary matrix with a row for `A & B`, `A & !B`, `!A & B`, `!A & !B`.
-Next, generate one column containing `true`s and one column for each rule in `rules`.
-In each column, answer whether the rule holds for some point that satisifies the conditional.
-This trick of taking specifically these rows is briliant.
-Credits go to D.W. on StackExchange (https://cs.stackexchange.com/a/152819/98402).
 """
 function _feature_space(rules::AbstractVector{Rule}, A::Split, B::Split)
     l = length(rules)
@@ -65,22 +55,27 @@ Return a vector of booleans with a true for every rule in `rules` that is linear
 To find rules for this method, collect all rules containing some feature for each pair of features.
 That should be a fairly quick way to find subsets that are easy to process.
 """
-function _linearly_dependent(rules::AbstractVector{Rule}, A::Split, B::Split)
+function _linearly_dependent(
+        rules::AbstractVector{Rule},
+        A::Split,
+        B::Split
+    )::BitArray
     data = _feature_space(rules, A, B)
     l = length(rules)
-    results = BitArray(undef, l)
+    dependent = BitArray(undef, l)
     result = 1
     for i in 1:l
         new_result = rank(view(data, :, 1:i+1))
-        if new_result == result + 1
+        rank_increased = new_result == result + 1
+        if rank_increased
             result = new_result
-            results[i] = 0
+            dependent[i] = false
         else
             result = new_result
-            results[i] = 1
+            dependent[i] = true
         end
     end
-    return results
+    return dependent
 end
 
 """

--- a/src/mlj.jl
+++ b/src/mlj.jl
@@ -360,12 +360,23 @@ function fit(model::StableRulesRegressor, verbosity::Int, X, y)
 end
 
 function predict(
-        model::Union{StableRulesClassifier, StableRulesRegressor},
+        model::StableRulesClassifier,
         fitresult::StableRules,
         Xnew
     )
     isempty(fitresult.rules) && error("Zero rules")
     return _predict(fitresult, matrix(Xnew))
+end
+
+function predict(
+        model::StableRulesRegressor,
+        fitresult::StableRules,
+        Xnew
+    )
+    isempty(fitresult.rules) && error("Zero rules")
+    predictions = _predict(fitresult, matrix(Xnew))
+    unpacked = [only(p) for p in predictions]
+    return unpacked
 end
 
 end # module

--- a/src/mlj.jl
+++ b/src/mlj.jl
@@ -70,7 +70,10 @@ julia> mach = machine(StableForestClassifier(), X, y);
 - `partial_sampling`:
     Ratio of samples to use in each subset of the data.
     The default of 0.7 should be fine for most cases.
-- `n_trees`: The number of trees to use.
+- `n_trees`:
+    The number of trees to use.
+    It is advisable to use at least thousand trees to for a better rule selection, and
+    in turn better predictive performance.
 - `max_depth`:
     The depth of the tree.
     A lower depth decreases model complexity and can therefore improve accuracy when the sample size is small (reduce overfitting).

--- a/src/mlj.jl
+++ b/src/mlj.jl
@@ -363,23 +363,12 @@ function fit(model::StableRulesRegressor, verbosity::Int, X, y)
 end
 
 function predict(
-        model::StableRulesClassifier,
+        model::Union{StableRulesClassifier, StableRulesRegressor},
         fitresult::StableRules,
         Xnew
     )
     isempty(fitresult.rules) && error("Zero rules")
     return _predict(fitresult, matrix(Xnew))
-end
-
-function predict(
-        model::StableRulesRegressor,
-        fitresult::StableRules,
-        Xnew
-    )
-    isempty(fitresult.rules) && error("Zero rules")
-    predictions = _predict(fitresult, matrix(Xnew))
-    unpacked = [only(p) for p in predictions]
-    return unpacked
 end
 
 end # module

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -453,7 +453,8 @@ function _sum(V::AbstractVector{<:AbstractVector})
 end
 
 function _predict(model::StableRules, row::AbstractVector)
-    isempty(_elements(model)) && _isempty_error(model)
-    probs = _predict.(_elements(model), Ref(row))
+    rules_weights = _elements(model)
+    isempty(rules_weights) && _isempty_error(model)
+    probs = _predict.(rules_weights, Ref(row))
     return _sum(probs)
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -131,6 +131,13 @@ function Base.values(rule::Rule)::Vector{Float64}
     return [Float64(_value(split)) for split in _splits(rule)]
 end
 
+"""
+    _reverse(rule::Rule)
+
+Return a reversed version of the `rule`.
+Assumes that the rule has only one split (clause) since two splits
+cannot be reversed.
+"""
 function _reverse(rule::Rule)
     splits = _splits(rule)
     @assert length(splits) == 1
@@ -158,15 +165,18 @@ end
 function _then_output!(
         leaf::Leaf,
         probs::Vector{LeafContent}
-    )
+    )::Vector{LeafContent}
     return push!(probs, _content(leaf))
 end
 
-"Return the output average of the training points which satisfy the rule."
+"""
+Add the leaf contents for the training points which satisfy the
+rule to the `probs` vector.
+"""
 function _then_output!(
         node::Node,
         probs::Vector{LeafContent}
-    )
+    )::Vector{LeafContent}
     _then_output!(node.left, probs)
     _then_output!(node.right, probs)
     return probs
@@ -176,16 +186,19 @@ function _else_output!(
         _,
         leaf::Leaf,
         probs::Vector{LeafContent}
-    )
+    )::Vector{LeafContent}
     return push!(probs, _content(leaf))
 end
 
-"Return the output average of the training points not covered by the rule."
+"""
+Add the leaf contents for the training points which do not satisfy
+the rule to the `probs` vector.
+"""
 function _else_output!(
         not_node::Union{Node,Leaf},
         node::Node,
         probs::Vector{LeafContent}
-    )
+    )::Vector{LeafContent}
     if node == not_node
         return probs
     end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -404,7 +404,7 @@ function StableRules(
     )::StableRules
     processed = _process_rules(rules, algo, model.max_rules)
     rules = first.(processed)
-    weights = _weights(rules, classes, data, outcome, model)
+    weights = _weights(rules, algo, classes, data, outcome, model)
     filtered_rules, filtered_weights = _remove_zero_weights(rules, weights)
     return StableRules(filtered_rules, algo, classes, filtered_weights)
 end

--- a/src/ruleshow.jl
+++ b/src/ruleshow.jl
@@ -1,0 +1,87 @@
+"""
+Return a feature name that can be shown as `[:, 1]` or `[:, :some_var]`.
+"""
+function _pretty_feature_name(feature::Int, feature_name::String255)
+    name = String(feature_name)::String
+    s = string(feature)::String
+    if s == name
+        return s
+    else
+        return string(':', name)
+    end
+end
+
+function _pretty_path(path::TreePath)
+    texts = map(path.splits) do split
+        sp = split.splitpoint
+        comparison = split.direction == :L ? '<' : '≥'
+        val = sp.value
+        feature = _pretty_feature_name(sp.feature, sp.feature_name)
+        text = "X[i, $feature] $comparison $val"
+    end
+    return join(texts, " & ")
+end
+
+function Base.show(io::IO, path::TreePath)
+    text = string("TreePath(\" ", _pretty_path(path), " \")")::String
+    print(io, text)
+end
+
+"Return only the last result for the binary case because the other is 1 - p anyway."
+function _simplify_binary_probabilities(
+        weight,
+        probs::LeafContent
+    )
+    if length(probs) == 2
+        left = first(probs)
+        right = last(probs)
+        if !isapprox(left + right, 1.0; atol=0.01)
+            @warn """
+                The sum of the two probabilities $probs doesn't add to 1.
+                This is unexpected.
+                Please open an issue at SIRUS.jl.
+                """
+        end
+        return round(weight * right; digits=3)
+    else
+        return round.(weight .* probs; digits=3)
+    end
+end
+
+function _simplify_regression_contents(
+        weight,
+        contents::LeafContent
+    )
+    content = only(contents)
+    return round(weight * content; digits=3)
+end
+
+"Return a pretty formatted so that it is easy to understand."
+function _pretty_rule(algo::Algorithm, weight, rule::Rule)
+    simplify = algo isa Classification ?
+        _simplify_binary_probabilities :
+        _simplify_regression_contents
+    then = simplify(weight, rule.then)
+    otherwise = simplify(weight, rule.otherwise)
+    condition = _pretty_path(rule.path)
+    return "if $condition then $then else $otherwise"
+end
+
+function Base.show(io::IO, model::StableRules)
+    l = length(model.rules)
+    rule_text = string("rule", l == 1 ? "" : "s")::String
+    println(io, "StableRules model with $l $rule_text:")
+    for i in 1:l
+        ending = i < l ? " +" : ""
+        rule = _pretty_rule(model.algo, model.weights[i], model.rules[i])
+        println(io, " $rule", ending)
+    end
+    if model.algo isa Classification
+        C = model.classes
+        lc = length(C)
+        note = lc == 2 ?
+        "\nNote: showing only the probability for class $(last(C)) since class $(first(C)) has probability 1 - p." :
+            ""
+        println(io, "and $lc classes: $C. $note")
+    end
+end

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -40,7 +40,7 @@ end
 Return the weights which are regularized to improve performance.
 
 !!! note
-    Make sure to use enough trees (thousands) for best accuracy.
+    This step requires many trees (thousands) for best accuracy.
 """
 function _weights(
         rules::Vector{Rule},

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -44,13 +44,19 @@ Return the weights which are regularized to improve performance.
 """
 function _weights(
         rules::Vector{Rule},
+        algo::Algorithm,
         classes::AbstractVector,
         data,
         outcome::AbstractVector,
-        model
+        model::Probabilistic
     )
-    binary_feature_data = _binary_features(rules, data)
-    y = convert(Vector{Float16}, outcome)
-    coefficients = _estimate_coefficients(binary_feature_data, y, model)
-    return coefficients::Vector{Float16}
+    if algo isa Classification
+        binary_feature_data = _binary_features(rules, data)
+        y = convert(Vector{Float16}, outcome)
+        coefficients = _estimate_coefficients(binary_feature_data, y, model)
+        return coefficients::Vector{Float16}
+    else
+         fraction = 1 / length(rules)
+         return Float16[fraction for _ in 1:length(rules)]
+     end
 end

--- a/test/classification.jl
+++ b/test/classification.jl
@@ -89,7 +89,7 @@ end
     @test all(>(0.95), dtree_accuracies)
 
     stree_accuracies = [_binary_accuracy(tree, classes, data, y) for tree in sforest.trees]
-    # @test all(>(0.95), stree_accuracies)
+    @test all(>(0.94), stree_accuracies)
 end
 
 fpreds = DecisionTree.apply_forest(dforest, data)

--- a/test/dependent.jl
+++ b/test/dependent.jl
@@ -106,10 +106,11 @@ let
     expected = [r1, r3, r5, r7, r8, r10, r13, r14, r16]
     @test wrap_filter(allrules) == expected
 
-    @test length(S._process_rules(allrules, 9)) == 9
-    @test length(S._process_rules(allrules, 10)) == 9
-    @test length(S._process_rules([r1], 9)) == 1
-    @test length(S._process_rules(repeat(allrules, 200), 9)) == 9
+    algo = SIRUS.Classification()
+    @test length(S._process_rules(allrules, algo, 9)) == 9
+    @test length(S._process_rules(allrules, algo, 10)) == 9
+    @test length(S._process_rules([r1], algo, 9)) == 1
+    @test length(S._process_rules(repeat(allrules, 200), algo, 9)) == 9
 end
 
 nothing

--- a/test/mlj.jl
+++ b/test/mlj.jl
@@ -192,6 +192,14 @@ let
     @test contains(fitresult, ":x1")
 end
 
+rulesmodel = StableRulesRegressor(; n_trees=50, rng=_rng())
+X, y = datasets["boston"]
+rulesmach = machine(rulesmodel, X, y)
+fit!(rulesmach; verbosity=0)
+preds = predict(rulesmach)
+@test preds isa Vector{Float64}
+# @test 0.95 < rsq(preds, y)
+
 let
     # e = _evaluate_baseline!(results, "boston")
 end

--- a/test/mlj.jl
+++ b/test/mlj.jl
@@ -192,7 +192,7 @@ let
     @test contains(fitresult, ":x1")
 end
 
-rulesmodel = StableRulesRegressor(; n_trees=50, rng=_rng())
+rulesmodel = StableRulesRegressor(; max_depth=1, n_trees=50, rng=_rng())
 X, y = datasets["boston"]
 rulesmach = machine(rulesmodel, X, y)
 fit!(rulesmach; verbosity=0)

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -78,18 +78,6 @@ end
 
 @test first(S._process_rules([r5, r1, r1], algo, 10)) == Pair(r1, 2)
 
-@testset "binary show" begin
-    r = S.Rule(S.TreePath(" X[i, 1] < 5 "), [0.1, 0.9], [0.2, 0.8])
-    classes = [0, 1]
-    weights = Float16[1.0]
-    model = S.StableRules([r], algo, classes, weights)
-    pretty = repr(model)
-    @test contains(pretty, "0.9")
-    @test contains(pretty, "0.8")
-    @test contains(pretty, "showing only")
-    @test !contains(pretty, "unexpected")
-end
-
 function generate_rules()
     algo = S.Classification()
     forest = S._forest(_rng(), algo, X, y)

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -33,9 +33,10 @@ r1b = S.Rule(S.TreePath(" X[i, 1] < 32000 "), [0.61], [0.408])
 r1c = S.Rule(S.TreePath(" X[i, 1] < 32000 "), [0.0], [0.408])
 r5 = S.Rule(S.TreePath(" X[i, 3] < 64 "), [0.56], [0.334])
 
+algo = SIRUS.Classification()
 let
     expected = [r1 => 2, r5 => 1]
-    @test S._combine_paths(S._flip_left([r5, r1, r1])) == expected
+    @test S._combine_paths(S._flip_left([r5, r1, r1]), algo) == expected
 end
 @test S._mean([[1, 4], [2, 4]]) == [1.5, 4.0]
 
@@ -58,8 +59,8 @@ rules = S._rules(forest)
 @test hash(r1) == hash(r1b)
 @test hash(r1.path) == hash(r1b.path)
 
-@test S._combine_paths([r1, r1b]) == [r1 => 2]
-@test first(only(S._combine_paths([r1, r1c]))).then_probs == [mean([0.61, 0])]
+@test S._combine_paths([r1, r1b], algo) == [r1 => 2]
+@test first(only(S._combine_paths([r1, r1c], algo))).then == [mean([0.61, 0])]
 @test S._count_unique([1, 1, 1, 2]) == Dict(1 => 3, 2 => 1)
 
 weights = [0.395, 0.197, 0.187, 0.057, 0.054, 0.043, 0.027, 0.02, 0.01, 0.01]
@@ -75,7 +76,7 @@ let
     @test S._predict(model, [33000, 0, 61]) == [mean([0.408, 0.56])]
 end
 
-@test first(S._process_rules([r5, r1, r1], 10)) == Pair(r1, 2)
+@test first(S._process_rules([r5, r1, r1], algo, 10)) == Pair(r1, 2)
 
 @testset "binary show" begin
     r = S.Rule(S.TreePath(" X[i, 1] < 5 "), [0.1, 0.9], [0.2, 0.8])

--- a/test/ruleshow.jl
+++ b/test/ruleshow.jl
@@ -20,11 +20,11 @@ end
     model = S.StableRules([r1, r2], algo, classes, weights)
     pretty = split(repr(model), '\n')
     @test pretty[1] == "StableRules model with 2 rules:"
-    then = round(0.6 * 0.1; digits=3)
-    otherwise = round(0.6 * 0.8; digits=3)
+    then = round(weights[1] * 0.1; digits=3)
+    otherwise = round(weights[1] * 0.8; digits=3)
     @test pretty[2] == " if X[i, 1] < 5.0 then $then else $otherwise +"
 
-    then = round(0.7 * 0.4; digits=3)
-    otherwise = round(0.7 * 0.6; digits=3)
+    then = round(weights[2] * 0.4; digits=3)
+    otherwise = round(weights[2] * 0.6; digits=3)
     @test pretty[3] == " if X[i, 2] < 3.0 then $then else $otherwise"
 end

--- a/test/ruleshow.jl
+++ b/test/ruleshow.jl
@@ -1,0 +1,30 @@
+@testset "binary show" begin
+    r = S.Rule(S.TreePath(" X[i, 1] < 5 "), [0.1, 0.9], [0.2, 0.8])
+    classes = [0, 1]
+    weights = Float16[1.0]
+    algo = SIRUS.Classification()
+    model = S.StableRules([r], algo, classes, weights)
+    pretty = repr(model)
+    @test contains(pretty, "0.9")
+    @test contains(pretty, "0.8")
+    @test contains(pretty, "showing only")
+    @test !contains(pretty, "unexpected")
+end
+
+@testset "regression show" begin
+    r1 = S.Rule(S.TreePath(" X[i, 1] < 5 "), [0.1], [0.8])
+    r2 = S.Rule(S.TreePath(" X[i, 2] < 3 "), [0.4], [0.6])
+    weights = Float16[0.6, 0.7]
+    algo = SIRUS.Regression()
+    classes = []
+    model = S.StableRules([r1, r2], algo, classes, weights)
+    pretty = split(repr(model), '\n')
+    @test pretty[1] == "StableRules model with 2 rules:"
+    then = round(0.6 * 0.1; digits=3)
+    otherwise = round(0.6 * 0.8; digits=3)
+    @test pretty[2] == " if X[i, 1] < 5.0 then $then else $otherwise +"
+
+    then = round(0.7 * 0.4; digits=3)
+    otherwise = round(0.7 * 0.6; digits=3)
+    @test pretty[3] == " if X[i, 2] < 3.0 then $then else $otherwise"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,10 @@ end
     include("rules.jl")
 end
 
+@testset "ruleshow" begin
+    include("ruleshow.jl")
+end
+
 @testset "dependent" begin
     include("dependent.jl")
 end


### PR DESCRIPTION
in order to find the bug in the `StableRulesRegressor` (#18).

## Notes

The bug seems to be related to the too high scores put in the rules:
```julia
julia> include("test/mlj.jl")

julia> preds[1:5]
5-element Vector{Float64}:
 286.98408203125
 280.405224609375
 306.151708984375
 310.74091796875
 310.74091796875

julia> rulesmach.fitresult
StableRules model with 7 rules:
 if X[i, :x6] < 6.8 then 48.767 else 65.298 +
 if X[i, :x11] < 19.2 then 45.919 else 36.811 +
 if X[i, :x13] < 9.04 then 40.428 else 31.213 +
 if X[i, :x3] < 3.97 then 22.868 else 18.279 +
 if X[i, :x10] < 437.0 then 49.438 else 39.331 +
 if X[i, :x1] < 2.44953 then 50.514 else 39.592 +
 if X[i, :x5] < 0.52 then 36.275 else 29.05

julia> rulesmach.fitresult.weights
7-element Vector{Float16}:
 2.066
 1.897
 1.486
 0.778
 2.197
 2.275
 1.475

julia> rulesmach.fitresult.rules
7-element Vector{SIRUS.Rule}:
 SIRUS.Rule(TreePath(" X[i, :x6] < 6.8 "), [23.6], [31.6])
 SIRUS.Rule(TreePath(" X[i, :x11] < 19.2 "), [24.2], [19.4])
 SIRUS.Rule(TreePath(" X[i, :x13] < 9.04 "), [27.2], [21.0])
 SIRUS.Rule(TreePath(" X[i, :x3] < 3.97 "), [29.4], [23.5])
 SIRUS.Rule(TreePath(" X[i, :x10] < 437.0 "), [22.5], [17.9])
 SIRUS.Rule(TreePath(" X[i, :x1] < 2.44953 "), [22.2], [17.4])
 SIRUS.Rule(TreePath(" X[i, :x5] < 0.52 "), [24.6], [19.7])
```
So the summary from the `rules` and `weights` is fine, but the `then` and `otherwise` contents make no sense since `y` is in a different range:
```julia
julia> y[1:5]
5-element Vector{Float64}:
 24.0
 21.6
 34.7
 33.4
 36.2
```
It could be something else, but the value of the `then` and `otherwise` seem the most likely culprit.

On second thought, the weights seem the most likely culprit. Those weights make no sense whereas the `then` and `otherwise` could correspond to `y` values.

Works towards fixing #16.