### PR TITLE
Fix bug in regression

### DIFF
--- a/docs/src/implementation-overview.md
+++ b/docs/src/implementation-overview.md
@@ -215,3 +215,7 @@ Next, generate one column containing `true`s and one column for each rule in `ru
 In each column, answer whether the rule holds for some point that satisifies the conditional.
 Next, calculate the rank and see whether the rank increases when adding additional rules.
 If the rank increases, then the added rule was not linearly dependent and if the rank does not increase, then the added rule is linearly dependent with earlier added rules.
+
+PROBABLY THE OUTCOME HAS TO BE NORMALIZED BEFORE FITTING THE WEIGHTS!!!
+
+Finally, the weights are determined by 

--- a/docs/src/implementation-overview.md
+++ b/docs/src/implementation-overview.md
@@ -216,6 +216,4 @@ In each column, answer whether the rule holds for some point that satisifies the
 Next, calculate the rank and see whether the rank increases when adding additional rules.
 If the rank increases, then the added rule was not linearly dependent and if the rank does not increase, then the added rule is linearly dependent with earlier added rules.
 
-PROBABLY THE OUTCOME HAS TO BE NORMALIZED BEFORE FITTING THE WEIGHTS!!!
-
-Finally, the weights are determined by 
+Finally, the weights are determined by ...

--- a/src/SIRUS.jl
+++ b/src/SIRUS.jl
@@ -11,7 +11,7 @@ using MLJLinearModels: MLJLinearModels, RidgeRegressor, glr
 using MLJModelInterface: UnivariateFinite, Probabilistic, fit
 using PrecompileSignatures: @precompile_signatures
 using Random: AbstractRNG, default_rng, seed!, shuffle
-using Statistics: mean, median
+using Statistics: mean, median, std
 using Tables: Tables, matrix
 
 export feature_names, directions, satisfies

--- a/src/weights.jl
+++ b/src/weights.jl
@@ -18,20 +18,55 @@ function _binary_features(rules::Vector{Rule}, data)
     return X
 end
 
+"Return using min-max normalization to scale the data to [0, 1]."
+function _normalize!(X::Vector{T}) where {T<:Real}
+    lower = minimum(X)
+    upper = maximum(X)
+    @inbounds @simd for i in eachindex(X)
+        X[i] = (X[i] - lower) / (upper - lower)
+    end
+    return X
+end
+
 """
 Return the coefficients obtained when fitting a regularized linear model over the binary features.
 The `lambda` specifies the strength of the L2 (ridge) regression.
+
+For example, the data for fitting could have the following variables:
+
+| Rule 1 | Rule 2 | Rule 3 | Outcome |
+|--------|--------|--------|---------|
+| ...... | ...... | ...... | ....... |
+
+The regression then finds a coeffient for each rule which is based on how much
+each rule is associated with the outcome. I don't know why this makes sense,
+but based on benchmarks it does.
+
+Note that the exact weights do not matter for the classification case, since
+the highest class will be selected anyway. For regression however, the weights
+should sum to roughly one.
 """
 function _estimate_coefficients(
+        algo::Algorithm,
         binary_feature_data::Matrix{Float16},
         outcome::Vector{Float16},
         model::Probabilistic
     )
+    # Lasso and ridge are non-invariant and thus require normalized data.
+    _normalize!(outcome)
+
     # Code is based on the definition for MMI.fit inside MLJLinearModels.jl.
     # Using Ridge because it allows an analytical solver.
     # Also, ElasticNet shows no clear benefit in accuracy.
+    # According to Clement, avoid Lasso since it would introduce additional
+    # sparsity and then instability in the rule selection.
     model = RidgeRegressor(; fit_intercept=false, model.lambda)
     coefs = MLJLinearModels.fit(glr(model), binary_feature_data, outcome)::Vector
+    if algo isa Regression
+        # Ensure that coefs sum roughly to one.
+        total = sum(coefs)
+        coefs = coefs ./ total
+    end
     # Avoid negative coefficients.
     return max.(coefs, 0)
 end
@@ -50,13 +85,8 @@ function _weights(
         outcome::AbstractVector,
         model::Probabilistic
     )
-    if algo isa Classification
-        binary_feature_data = _binary_features(rules, data)
-        y = convert(Vector{Float16}, outcome)
-        coefficients = _estimate_coefficients(binary_feature_data, y, model)
-        return coefficients::Vector{Float16}
-    else
-         fraction = 1 / length(rules)
-         return Float16[fraction for _ in 1:length(rules)]
-     end
+    binary_feature_data = _binary_features(rules, data)
+    y = convert(Vector{Float16}, outcome)
+    coefficients = _estimate_coefficients(algo, binary_feature_data, y, model)
+    return coefficients::Vector{Float16}
 end

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -11,4 +11,9 @@ binary_feature_data = Float16[1 0; 0 0; 1 1]
 y = Float16[0.5, 0, 1]
 
 model = StableRulesClassifier()
-@test S._estimate_coefficients(binary_feature_data, y, model) isa Vector
+algo = S.Classification()
+@test S._estimate_coefficients(algo, binary_feature_data, y, model) isa Vector
+
+@test SIRUS._normalize!([1.0, 2.0, 3.0]) == [0.0, 0.5, 1.0]
+
+nothing


### PR DESCRIPTION
Normalizing the regularized fit on the weights improves the predictive performance from  to -1300.0 ± 248 to 0.33 ± 0.04. However, there is still something wrong since it should be near 0.6.